### PR TITLE
fix: set honkify emotion dependency to *

### DIFF
--- a/sites/honkify/package.json
+++ b/sites/honkify/package.json
@@ -8,7 +8,7 @@
     "develop": "gatsby develop"
   },
   "dependencies": {
-    "@emotion/core": "^10.0.17",
+    "@emotion/core": "*",
     "@mdx-js/mdx": "^1.5.0",
     "@mdx-js/react": "^1.5.0",
     "@theme-ui/prism": "^0.2.40",


### PR DESCRIPTION
Theme UI requires that only a single version of `@emotion/core` is installed. Since Honkify is an existing site that we’re retroactively adding a theme to, it already has Emotion installed as a dependency.

This fix makes sure that whatever version of Emotion the theme installs will also be used for honkify, avoiding a confusing bug. See this Twitter thread for details: https://twitter.com/chrisbiscardi/status/1211749202163687424